### PR TITLE
Album/Art restructure

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,9 +85,9 @@
         <div id="artistPage" class="collapsed">
             <!-- Artist Name -->
             <section>
-                <div id="artistBanner" class="relative bg-teal-900 text-green-100 p-0 pb-5 flex content-end">
-                    <div class="relative flex-shrink-0" style="height:200px!important; width:200px!important;">
-                        <div class="absolute rounded-full h-full w-full overflow-hidden shadow-lg" style="bottom:-20px;">
+                <div id="artistBanner" class="relative bg-teal-900 text-green-100 p-0 pb-5 flex content-end overflow-hidden">
+                    <div class="relative flex-shrink-0 mx-2" style="height:200px!important; width:200px!important;">
+                        <div class="absolute rounded-full h-full w-full overflow-hidden shadow-lg" style="bottom:-40px;">
                             <img id="artistBannerPic" class="h-full w-full" src="", alt="">
                         </div>
                     </div>
@@ -98,7 +98,7 @@
                         <div id="genreWell" class=""></div>
                     </div>
                     <span class="absolute bottom-0 right-0 mr-1">
-                        courtesey of <a href="https://www.vagalume.com.br" id="vagaLink"
+                        courtesy of <a href="https://www.vagalume.com.br" id="vagaLink"
                             class="text-green-400">vagalume</a>
                     </span>
                 </div>
@@ -109,7 +109,7 @@
                 <h2 class="bg-teal-700 text-green-100 text-2xl font-bold p-3">
                     Albums
                 </h2>
-                <div id="albumWell" class= "bg-gray-400"></div>
+                <div id="albumWell" class="flex flex-wrap bg-gray-400"></div>
             </section>
 
             <!-- Related Artists -->


### PR DESCRIPTION
- re-formatted artist header image css
- added musicBrainz api
    - removed vagalume album printing
    - incorporated musicBrainz albums + artwork
        - this can return multipler copies of a track, so come back and check on this later